### PR TITLE
performance improvements to event handler

### DIFF
--- a/src/main/java/thretcha/roadrunner/RoadHandler.java
+++ b/src/main/java/thretcha/roadrunner/RoadHandler.java
@@ -1,9 +1,11 @@
 package thretcha.roadrunner;
 
 import com.google.common.collect.Sets;
+import net.minecraft.block.Block;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -19,6 +21,8 @@ public class RoadHandler {
     public static Map<String,UUID> ROAD_BLOCKS = new HashMap<>();
     //stores the Road Blocks in the correct order so their modifier uuids are easier to get
     public static String []ROAD_BLOCK_IDS={"","","","",""};
+    //caches block names for quick lookup
+    private static Map<Block,String> BLOCK_NAME_CACHE = new IdentityHashMap<>();
 
     public static void initRoadModifierUUIDList(){
         ROAD_MODIFIER_UUID_LIST.add(UUID.fromString("8753f773-a718-4ea8-98db-4318be0159fe"));
@@ -35,32 +39,16 @@ public class RoadHandler {
         ROAD_MODIFIER_LIST.add(new AttributeModifier(ROAD_MODIFIER_UUID_LIST.get(3), "Road 4 Speed Modifier", Config.BLOCK_AMOUNT_4, Config.BLOCK_OPERATION_4));
         ROAD_MODIFIER_LIST.add(new AttributeModifier(ROAD_MODIFIER_UUID_LIST.get(4), "Road 5 Speed Modifier", Config.BLOCK_AMOUNT_5, Config.BLOCK_OPERATION_5));
     }
-    private boolean hasRoadModifier(EntityLivingBase entity){
 
-        Set<AttributeModifier> modifierSet = Sets.<AttributeModifier>newHashSet();
-        modifierSet= (Set)entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getModifiers();
-        Boolean ret = false;
-        for (AttributeModifier modifier : modifierSet) {
-            if(ROAD_MODIFIER_LIST.contains(modifier)) {
-                ret = true;
-                break;
-            }
-        }
-        return ret;
-    }
     //returns null when the entity doesn't contain a road modifier
     private AttributeModifier getRoadModifier(EntityLivingBase entity){
-        entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getModifiers();
-        Set<AttributeModifier> modifierSet = Sets.<AttributeModifier>newHashSet();
-        modifierSet= (Set)entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getModifiers();
-        AttributeModifier ret = null;
-        for (AttributeModifier modifier : modifierSet) {
-            if(ROAD_MODIFIER_LIST.contains(modifier)) {
-                ret=modifier;
-                break;
+        IAttributeInstance attribute = entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED);
+        for (AttributeModifier modifier: ROAD_MODIFIER_LIST){
+            if (attribute.hasModifier(modifier)){
+                return modifier;
             }
         }
-        return ret;
+        return null;
     }
 
     @SubscribeEvent
@@ -71,33 +59,34 @@ public class RoadHandler {
         if (!entity.getEntityWorld().isRemote)
         {
             BlockPos position = ((EntityLivingBase) event.getEntity()).getPosition().down();
-            String BlockUnderEntity = entity.getEntityWorld().getBlockState(position).getBlock().toString();
-
+            String BlockUnderEntity = BLOCK_NAME_CACHE.computeIfAbsent(entity.getEntityWorld().getBlockState(position).getBlock(), Block::toString);
 
             //entity walked from non Road Block to a Road Block !livingEntitiesOnRoad.containsKey(entity)
-            if(ROAD_BLOCKS.containsKey(BlockUnderEntity)&&!hasRoadModifier(entity))
+            AttributeModifier roadModifier = getRoadModifier(entity);
+            boolean hasRoadModifier = roadModifier != null;
+            if(ROAD_BLOCKS.containsKey(BlockUnderEntity)&&!hasRoadModifier)
             {
                 //add new Road Block modifier
                 addCorrectRoadModifier(entity, BlockUnderEntity);
             }
             //if the entity walked from a Road Block to a Road Block of the same Type
             //do nothing
-           else if(ROAD_BLOCKS.containsKey(BlockUnderEntity)&&getRoadModifier(entity).getID().equals(ROAD_BLOCKS.get(BlockUnderEntity)))
+           else if(ROAD_BLOCKS.containsKey(BlockUnderEntity)&&roadModifier.getID().equals(ROAD_BLOCKS.get(BlockUnderEntity)))
             {
 
             }
             //entity walked from a Road Block to a non Road Block
-            else if(!ROAD_BLOCKS.containsKey(BlockUnderEntity)&&hasRoadModifier(entity))
+            else if(!ROAD_BLOCKS.containsKey(BlockUnderEntity)&& hasRoadModifier)
             {
                 //remove Road Block modifier
-                entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).removeModifier(getRoadModifier(entity).getID());
+                entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).removeModifier(roadModifier);
             }
 
             //entity walked from a Road Block to a different type of Road Block
-            else if(ROAD_BLOCKS.containsKey(BlockUnderEntity)&&ROAD_BLOCKS.get(BlockUnderEntity).equals(getRoadModifier(entity).getID())) {
+            else if(ROAD_BLOCKS.containsKey(BlockUnderEntity)&&ROAD_BLOCKS.get(BlockUnderEntity).equals(roadModifier)) {
 
                 //remove old Road Block modifier
-                entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).removeModifier(getRoadModifier(entity).getID());
+                entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).removeModifier(roadModifier);
                 //add new Road Block modifier
                 addCorrectRoadModifier(entity,BlockUnderEntity);
             }
@@ -130,23 +119,23 @@ public class RoadHandler {
     }
     //To do figure out how to add roadblocks in the config in a non hard coded way
     public static void addRoadBlocksFromConfig(){
-        if(Config.BLOCK_ID_1!="") {
+        if(!Config.BLOCK_ID_1.equals("")) {
             ROAD_BLOCKS.put("Block{" + Config.BLOCK_ID_1 + "}", ROAD_MODIFIER_LIST.get(0).getID());
             ROAD_BLOCK_IDS[0]="Block{" + Config.BLOCK_ID_1 + "}";
         }
-        if(Config.BLOCK_ID_2!="") {
+        if(!Config.BLOCK_ID_2.equals("")) {
             ROAD_BLOCKS.put("Block{" + Config.BLOCK_ID_2 + "}", ROAD_MODIFIER_LIST.get(1).getID());
             ROAD_BLOCK_IDS[1]="Block{" + Config.BLOCK_ID_2 + "}";
         }
-        if(Config.BLOCK_ID_3!="") {
+        if(!Config.BLOCK_ID_3.equals("")) {
             ROAD_BLOCKS.put("Block{" + Config.BLOCK_ID_3 + "}", ROAD_MODIFIER_LIST.get(2).getID());
             ROAD_BLOCK_IDS[2]="Block{" + Config.BLOCK_ID_3 + "}";
         }
-        if(Config.BLOCK_ID_4!="") {
+        if(!Config.BLOCK_ID_4.equals("")) {
             ROAD_BLOCKS.put("Block{" + Config.BLOCK_ID_4 + "}", ROAD_MODIFIER_LIST.get(3).getID());
             ROAD_BLOCK_IDS[3]="Block{" + Config.BLOCK_ID_4 + "}";
         }
-        if(Config.BLOCK_ID_5!="") {
+        if(!Config.BLOCK_ID_5.equals("")) {
             ROAD_BLOCKS.put("Block{" + Config.BLOCK_ID_5 + "}", ROAD_MODIFIER_LIST.get(4).getID());
             ROAD_BLOCK_IDS[4]="Block{" + Config.BLOCK_ID_5 + "}";
         }


### PR DESCRIPTION
Noticed your mod showing up in profiler runs as a heavy culprit, so I made some changes which have been good for my server.

- Using strings for block testing is not good, but the cache improves things for the meantime (avoids expensive string building)
- `Set<AttributeModifier> modifierSet = Sets.<AttributeModifier>newHashSet();` was redundant as you're overwriting it the next line
- `entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getModifiers()` *copies* the list, so reversing the logic is needed
- `hasRoadModifier` isnt really necessary, as you can just null check
- Various other variable caching.